### PR TITLE
Call step(...) in enableOutputs() to ensure motor pins are driven in …

### DIFF
--- a/src/AccelStepper.cpp
+++ b/src/AccelStepper.cpp
@@ -601,6 +601,10 @@ void    AccelStepper::enableOutputs()
         pinMode(_enablePin, OUTPUT);
         digitalWrite(_enablePin, HIGH ^ _enableInverted);
     }
+
+    // Ensure pins are updated for the current position to make sure
+    // motor is powered following disableOutputs().
+    step(_currentPos);
 }
 
 void AccelStepper::setMinPulseWidth(unsigned int minWidth)


### PR DESCRIPTION
Small addition to enableOutputs() to ensure motor pins are driven. 

Previously pins were turned off in disable and remained off until the first call to step() following a call to enableOutputs(). In situations where multiple steppers contribute to moving an effector (5 link robot for example) an enabled stepper that hasn't been moved could be pushed around by a moving stepper connected to a common effector. This update fixes the issue by ensuring that all enabled motors have their coils powered when enabled.