### PR TITLE
Corrected Acceleration Limited Max Speed

### DIFF
--- a/src/AccelStepper.cpp
+++ b/src/AccelStepper.cpp
@@ -99,7 +99,7 @@ unsigned long AccelStepper::computeNewSpeed()
 {
     long distanceTo = distanceToGo(); // +ve is clockwise from curent location
 
-    long stepsToStop = (long)((_speed * _speed) / (2.0 * _acceleration)); // Equation 16
+    long stepsToStop = abs(_n); // Equation 16
 
     if (distanceTo == 0 && stepsToStop <= 1)
     {
@@ -155,7 +155,7 @@ unsigned long AccelStepper::computeNewSpeed()
     else
     {
 	// Subsequent step. Works for accel (n is +_ve) and decel (n is -ve).
-	_cn = _cn - ((2.0 * _cn) / ((4.0 * _n) + 1)); // Equation 13
+	_cn = ((2.0 * _c0) / ((4.0 * _n) + 1)); // Equation 13
 	_cn = max(_cn, _cmin); 
     }
     _n++;


### PR DESCRIPTION
Previously _cn could never significantly drop below its initial value, leading to cases where low accelerations meant it could never exceed a speed value of about 1361000 / sqrt(acceleration)

This fix is to correct it such that the libraries speed limit is the only thing limiting the maximum speed, This may have the consequence of changing the acceleration scaling at higher speeds slightly, as it no longer rolls off, instead increasing to the cruise phase